### PR TITLE
Set the version when trying to download an existing version

### DIFF
--- a/ocp4-downloader
+++ b/ocp4-downloader
@@ -135,7 +135,7 @@ function download_product() {
 
   # pre-installation tasks
   cleanup_if_force ${PREFIX} ${FILENAME}
-  check_if_exists ${PREFIX} ${FILENAME} ${DOWNLOAD} || return
+  check_if_exists ${PREFIX} ${FILENAME} ${DOWNLOAD} || DOWNLOAD="NO"
 
   # dont download, just update symlink
   if [[ ${DOWNLOAD} == "NO" ]]; then


### PR DESCRIPTION
If we try to download an existing OCP version, it behaves as --set instead of just doing nothing. This is more expected behavior, because if I choose a version to be donwloaded, it is because I want it, regardless of whether I downloaded it in the past and forgot or not